### PR TITLE
Install metadata not received on Android with custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ To add the plugin to your Cordova project, simply add the plugin from the npm re
 * `YOZIO_APP_SECRET` - Your Yozio secret key (available from the Yozio console)
 * `URL_SCHEME` - Your application's custom URL scheme (enter `appname` to use `appname://...`)
 * `YOZIO_ENABLE_IOS_UNIVERSAL_LINKS` Indicates if you are using iOS Universal Links (should be `YES` or `NO`)
-* `YOZIO_IOS_UNIVERSAL_LINK_DOMAIN` The custom domain you are using with iOS Universal Links
+* `YOZIO_DOMAIN` The domain you are using for your SuperLinks (if you aren't using a custom domain, then specify `r.yoz.io`)
 
 For example, an app with all an app key of `123`, secret key of `456`, a link scheme of `appname://...` and iOS universal link support with the custom domain `r.company.com`, the command would look like this:
 
-    cordova plugin add cordova-plugin-yozio --variable YOZIO_APP_KEY=123 --variable YOZIO_APP_SECRET=456 --variable URL_SCHEME=appname --variable=YOZIO_ENABLE_IOS_UNIVERSAL_LINKS=YES --variable=YOZIO_IOS_UNIVERSAL_LINK_DOMAIN=r.company.com
+    cordova plugin add cordova-plugin-yozio --variable YOZIO_APP_KEY=123 --variable YOZIO_APP_SECRET=456 --variable URL_SCHEME=appname --variable=YOZIO_ENABLE_IOS_UNIVERSAL_LINKS=YES --variable=YOZIO_DOMAIN=r.company.com
 
-> Note: Even if you are not using iOS universal links, the parameters still need to be specified. You can use `YOZIO_ENABLE_IOS_UNIVERSAL_LINKS=NO` and `YOZIO_IOS_UNIVERSAL_LINK_DOMAIN=r.yoz.io` in this case.
+> Note: Even if you are not using iOS universal links or a custom domain, the parameters still need to be specified. You can use `YOZIO_ENABLE_IOS_UNIVERSAL_LINKS=NO` and `YOZIO_DOMAIN=r.yoz.io` in this case.
 
 Alternatively, you can install plugin directly from git by replacing the plugin ID with the git URL: `https://github.com/Justin-Credible/cordova-plugin-yozio#1.0.3`
 

--- a/hooks/ios-configure-entitlements.js
+++ b/hooks/ios-configure-entitlements.js
@@ -86,19 +86,19 @@ module.exports = function (ctx) {
             var platformConfigPath = path.join(ctx.opts.projectRoot, "platforms", "ios", "ios.json");
 
             var platformConfig = require(platformConfigPath);
-            var domain = platformConfig.installed_plugins[PLUGIN_ID].YOZIO_IOS_UNIVERSAL_LINK_DOMAIN;
+            var domain = platformConfig.installed_plugins[PLUGIN_ID].YOZIO_DOMAIN;
 
             if (!domain) {
                 domain = "r.yoz.io";
             }
 
-            console.log("Adding $YOZIO_IOS_UNIVERSAL_LINK_DOMAIN '" + domain + "' to entitlements file " + entitlementsFilePath);
+            console.log("Adding $YOZIO_DOMAIN '" + domain + "' to entitlements file " + entitlementsFilePath);
 
             var entitlementsFilePath = path.join(ctx.opts.projectRoot, "platforms", "ios", projName, "Resources", "yozio-plugin.entitlements");
 
             // Perform a replacement of the variable in the entitlements file.
             var contents = fs.readFileSync(entitlementsFilePath, "utf-8");
-            contents = contents.replace("$YOZIO_IOS_UNIVERSAL_LINK_DOMAIN", "applinks:" + domain);
+            contents = contents.replace("$YOZIO_DOMAIN", "applinks:" + domain);
             fs.writeFileSync(entitlementsFilePath, contents, "utf8");
 
             // Add the entitlements file reference to the project file.

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@
     <preference name="YOZIO_APP_KEY" />
     <preference name="YOZIO_SECRET_KEY" />
     <preference name="YOZIO_IOS_ENABLE_UNIVERSAL_LINKS" />
-    <preference name="YOZIO_IOS_UNIVERSAL_LINK_DOMAIN" />
+    <preference name="YOZIO_DOMAIN" />
 
     <!-- JavaScript Interface -->
     <js-module src="www/yozio-plugin.js" name="YozioPlugin">
@@ -66,7 +66,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="deeplink.yozio.com" android:path="/$YOZIO_APP_KEY" />
+                <data android:scheme="https" android:host="$YOZIO_DOMAIN" android:pathPrefix="/$YOZIO_APP_KEY" />
             </intent-filter>
         </config-file>
 
@@ -102,7 +102,7 @@
         </config-file>
 
         <config-file target="*-Info.plist" parent="YozioIosUniversalLinkDomain">
-            <string>$YOZIO_IOS_UNIVERSAL_LINK_DOMAIN</string>
+            <string>$YOZIO_DOMAIN</string>
         </config-file>
 
         <config-file target="*-Info.plist" parent="CFBundleURLTypes">

--- a/src/ios/yozio-plugin.entitlements
+++ b/src/ios/yozio-plugin.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>$YOZIO_IOS_UNIVERSAL_LINK_DOMAIN</string>
+		<string>$YOZIO_DOMAIN</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
• Renamed YOZIO_IOS_UNIVERSAL_LINK_DOMAIN to YOZIO_DOMAIN as it is also used by Android
• Intent filter now uses the domain supplied by $YOZIO_DOMAIN instead of the hardcoded deeplink.yozio.com
• Intent filter now uses pathPrefix instead of path