### PR TITLE
Fix an issue with iOS initial launch not handling a deeplink.

### DIFF
--- a/src/ios/AppDelegate+YozioPlugin.m
+++ b/src/ios/AppDelegate+YozioPlugin.m
@@ -182,6 +182,15 @@
               sourceApplication:(NSString *)sourceApplication
                      annotation:(id)annotation {
 
+    // If we already handled the deep link in continueUserActivity,
+    // just run the original method and bail.
+    if ([YozioPlugin wasOpenedViaDeepLink]) {
+        return [self yozioPlugin_application:application
+                                     openURL:url
+                           sourceApplication:sourceApplication
+                                  annotation:annotation];
+    }
+    
     // Track the deep link with Yozio.
     int result = [Yozio handleOpenURL: url];
 


### PR DESCRIPTION
- If the app was installed, but never launched and then opened from a Yozio deep link, it would not correctly pass that metadata.  OpenUrl was being called after continueUserActivity and setting wasOpenedViaDeepLink to NO after it had already been set to YES.