### PR TITLE
Disable use_sf_safari_view_controller - doesn't work on iOS 10.

### DIFF
--- a/libs/ios/Resources/YozioDefaults.plist
+++ b/libs/ios/Resources/YozioDefaults.plist
@@ -7,6 +7,6 @@
 	<key>request_timeout</key>
 	<integer>7</integer>
 	<key>use_sf_safari_view_controller</key>
-	<true/>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
- Using SFSafariViewController for 100% matching is no longer supported in iOS 10. Disabling via config.
